### PR TITLE
feat: Auto-detect HOSTIP in host network mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,20 +4,11 @@ export DOCKER_BUILDKIT := 1
 export DOCKER_SCAN_SUGGEST := false
 export COMPOSE_DOCKER_CLI_BUILD := 1
 
-ifndef HOSTIP
-	ifeq ($(OS),Windows_NT)
-		HOSTIP := $(shell powershell -command '(Get-NetIPConfiguration | Where-Object {$$_.IPv4DefaultGateway -ne $$null -and $$_.NetAdapter.Status -ne "Disconnected"}).IPv4Address.IPAddress' )
-	else
-		ifeq ($(UNAME_S),Linux)
-			HOSTIP := $(shell ip route get 1 | head -1 | awk '{print $$7}' )
-		endif
-		ifeq ($(UNAME_S),Darwin)
-			HOSTIP := $(shell ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $$2}' )
-		endif
-	endif
-endif
-
+# HOSTIP is now auto-detected inside the container (host network mode)
+# Set it here only if you need to override the detected value
+ifdef HOSTIP
 export HOSTIP
+endif
 export UPSTREAM_DNS
 
 # -------------------------------

--- a/app/joyride.rb
+++ b/app/joyride.rb
@@ -14,10 +14,28 @@ require_relative 'dns_generator'
 # no buffering output
 $stdout.sync = true
 
+# Auto-detect HOSTIP if not provided (works in host network mode)
+def detect_host_ip(log)
+  return ENV['HOSTIP'] if ENV['HOSTIP'] && !ENV['HOSTIP'].strip.empty?
+
+  detected_ip = `ip route get 1 2>/dev/null | head -1 | awk '{print $7}'`.strip
+  if detected_ip.empty?
+    log.error "HOSTIP not set and auto-detection failed. DNS entries will be malformed."
+    log.error "Set HOSTIP environment variable or ensure container runs in host network mode."
+    return nil
+  end
+
+  log.info "Auto-detected HOSTIP: #{detected_ip}"
+  detected_ip
+end
+
 locator = {}
 
 log = Logger.new($stdout)
 log.formatter = proc { |severity, datetime, progname, msg| "#{msg}\n" }
+
+# Set HOSTIP from auto-detection if not already set
+ENV['HOSTIP'] = detect_host_ip(log) unless ENV['HOSTIP'] && !ENV['HOSTIP'].strip.empty?
 
 file_path = "/etc/hosts.d/hosts"
 begin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     container_name: joyride
     restart: unless-stopped
     environment:
-      - HOSTIP=${HOSTIP}
+      # HOSTIP is auto-detected in host network mode; set to override
+      - HOSTIP=${HOSTIP:-}
       #- UPSTREAM_DNS=${UPSTREAM_DNS}
       - JOYRIDE_NXDOMAIN_ENABLED=${JOYRIDE_NXDOMAIN_ENABLED:-false}
       - JOYRIDE_LOG_DEBUG=${JOYRIDE_LOG_DEBUG:-false}


### PR DESCRIPTION
- Add detect_host_ip function to joyride.rb that uses 'ip route get 1' to automatically detect the host IP address when running in host network mode
- Set ENV['HOSTIP'] from auto-detection if not already provided
- Make HOSTIP environment variable optional in docker-compose.yml
- Simplify Makefile HOSTIP logic since container now auto-detects

This eliminates the need to manually set HOSTIP when using host network mode, fixing malformed /etc/dnsmasq.d/hosts files that were missing IP addresses.