### PR TITLE
ci: trigger docker-publish on release tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,15 +4,11 @@ on:
   workflow_dispatch:
   push:
     branches: [ '**' ]
-    paths:
-      - 'plugins/**/*'
-      - 'Dockerfile'
-      - 'Corefile'
-      - 'Corefile.cluster'
-      - 'go.mod'
-      - 'go.sum'
-      - 'plugin.cfg'
-      - '.github/workflows/docker-publish.yml'
+    # Trigger on release tags so release-please-created tags publish a
+    # semver-tagged image. paths filters cannot be used here -- they block
+    # tag-push events (which lack file-change context). Build cache keeps
+    # branch-push runs cheap when nothing relevant changed.
+    tags: [ 'v*' ]
   pull_request:
     branches: [ "coredns" ]
     types: [ closed ]


### PR DESCRIPTION
## Summary
- Add `tags: [ 'v*' ]` to the `push:` trigger of `docker-publish.yml` so release-please-created tags push a semver-tagged image to ghcr.io automatically.
- Drop the `paths:` filter on the same trigger. `paths` filters block tag-push events (tag pushes have no file-change context), so we either keep `paths` or get tag triggers, not both. Build cache keeps branch-push runs cheap.

## Why
Release-please runs as `GITHUB_TOKEN`, and GitHub deliberately does not cascade workflows from token-triggered events. The existing `release: published` trigger has therefore never fired -- every release to date required a manual `gh workflow run docker-publish.yml --ref v<tag>` to publish the semver-tagged image. v2.4.4 needed this today; this PR removes the manual step for future releases.

## Test plan
- [x] YAML parses (no syntax error)
- [ ] Merge, then verify next release-please tag triggers a docker-publish run automatically