### PR TITLE
docs: explain build-time import path for version package

### DIFF
--- a/plugins/docker-cluster/docker_cluster.go
+++ b/plugins/docker-cluster/docker_cluster.go
@@ -11,6 +11,10 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/fall"
 	"github.com/coredns/coredns/plugin/pkg/log"
+	// Path resolves only at Docker build time, after this directory is copied
+	// into the cloned CoreDNS source tree at /build/coredns/plugin/docker-cluster.
+	// Static analyzers (CodeQL, `go build` from this repo root) cannot resolve
+	// it; the warning is expected.
 	"github.com/coredns/coredns/plugin/docker-cluster/version"
 	"github.com/coredns/coredns/request"
 	"github.com/miekg/dns"

--- a/plugins/docker-cluster/version/version.go
+++ b/plugins/docker-cluster/version/version.go
@@ -2,7 +2,10 @@
 package version
 
 // Version information set at build time via ldflags.
-// Example: go build -ldflags="-X 'github.com/traefikturkey/joyride/plugins/docker-cluster/version.Version=1.0.0'"
+// At build time this package's import path is
+// github.com/coredns/coredns/plugin/docker-cluster/version
+// because the plugin source is copied into the cloned CoreDNS module tree.
+// See the Dockerfile builder stage for the matching -X flags.
 var (
 	// Version is the semantic version (e.g., "1.0.0")
 	Version = "dev"


### PR DESCRIPTION
## Summary
Adds a short note at the cross-module import in \`docker_cluster.go\` explaining that the path \`github.com/coredns/coredns/plugin/docker-cluster/version\` only resolves at Docker build time, after the plugin is copied into the cloned CoreDNS source tree. Static analyzers (CodeQL, \`go build\` from the repo root) cannot resolve it and emit a warning that is expected and not actionable.

Also replaces a stale ldflags example in \`version.go\` that referenced \`github.com/traefikturkey/joyride/...\` -- a path that has never been correct.

## Why not a structural fix?
The unresolved package contains only ldflags-injected version strings and a small JSON HTTP handler. Nothing security-relevant. Adding a \`replace\` directive or restructuring imports adds complexity without changing what CodeQL would actually catch.

## Test plan
- [x] Comments are syntactically valid Go (no compile impact)
- [ ] CI green